### PR TITLE
feat: proxy password security - encryption at rest and secure peek endpoint

### DIFF
--- a/api/routes/auth.go
+++ b/api/routes/auth.go
@@ -1,0 +1,120 @@
+package routes
+
+import (
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"runtime"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+)
+
+func authRouter() http.Handler {
+	r := chi.NewRouter()
+	r.Post("/verify-password", verifyPassword)
+	return r
+}
+
+type verifyPasswordRequest struct {
+	Password string `json:"password"`
+}
+
+// verifyPassword checks the given password against the current OS user's credentials.
+// On macOS: uses `dscl . -authonly <username> <password>`
+// On Windows: uses PowerShell LogonUser via Win32 API
+func verifyPassword(w http.ResponseWriter, r *http.Request) {
+	var req verifyPasswordRequest
+	if err := render.DecodeJSON(r.Body, &req); err != nil || req.Password == "" {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, render.M{"verified": false, "error": "password required"})
+		return
+	}
+
+	verified := false
+	var verifyErr string
+
+	switch runtime.GOOS {
+	case "darwin":
+		verified, verifyErr = verifyMacOS(req.Password)
+	case "windows":
+		verified, verifyErr = verifyWindows(req.Password)
+	default:
+		verifyErr = "unsupported platform"
+	}
+
+	if verifyErr != "" {
+		render.Status(r, http.StatusInternalServerError)
+		render.JSON(w, r, render.M{"verified": false, "error": verifyErr})
+		return
+	}
+
+	if !verified {
+		render.Status(r, http.StatusUnauthorized)
+		render.JSON(w, r, render.M{"verified": false})
+		return
+	}
+
+	render.JSON(w, r, render.M{"verified": true})
+}
+
+func verifyMacOS(password string) (bool, string) {
+	// Get current username
+	u, err := user.Current()
+	if err != nil {
+		return false, "cannot determine current user"
+	}
+	username := u.Username
+	// Strip domain prefix if present (e.g. "DOMAIN\user")
+	if idx := strings.LastIndex(username, "\\"); idx >= 0 {
+		username = username[idx+1:]
+	}
+
+	// dscl . -authonly <username> <password>
+	// Returns exit code 0 if correct, non-zero if wrong
+	cmd := exec.Command("/usr/bin/dscl", ".", "-authonly", username, password)
+	// Suppress output
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	err = cmd.Run()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			_ = exitErr
+			return false, "" // wrong password, not an error
+		}
+		return false, err.Error()
+	}
+	return true, ""
+}
+
+func verifyWindows(password string) (bool, string) {
+	username := os.Getenv("USERNAME")
+	if username == "" {
+		return false, "cannot determine current user"
+	}
+
+	script := `
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public class WinAuth {
+    [DllImport("advapi32.dll", SetLastError=true)]
+    public static extern bool LogonUser(string user, string domain, string pass,
+        int logonType, int logonProvider, out IntPtr token);
+    [DllImport("kernel32.dll")] public static extern bool CloseHandle(IntPtr h);
+}
+"@
+$token = [IntPtr]::Zero
+$ok = [WinAuth]::LogonUser("` + username + `", $env:USERDOMAIN, "` + password + `", 2, 0, [ref]$token)
+if ($token -ne [IntPtr]::Zero) { [WinAuth]::CloseHandle($token) | Out-Null }
+Write-Output $ok
+`
+	cmd := exec.Command("powershell.exe", "-noprofile", "-NonInteractive", "-command", script)
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err.Error()
+	}
+	return strings.TrimSpace(string(out)) == "True", ""
+}

--- a/api/routes/proxy.go
+++ b/api/routes/proxy.go
@@ -26,6 +26,7 @@ func proxyRouter() http.Handler {
 	r := chi.NewRouter()
 	r.Get("/", getProxies)
 	r.Get("/cur-proxy", handleGetProxy)
+	r.Get("/{proxyId}", getProxy) // NEW: get single proxy with password
 	r.Put("/", addProxy)
 	r.Delete("/all", deleteAllProxies)
 	r.Delete("/", deleteProxies)
@@ -126,6 +127,8 @@ func getProxyDelay(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// getProxies returns all proxies with passwords STRIPPED for security.
+// The web dashboard cannot see passwords through this endpoint.
 func getProxies(w http.ResponseWriter, r *http.Request) {
 	proxiesMap, err := configuration.GetProxies()
 	if err != nil {
@@ -141,12 +144,31 @@ func getProxies(w http.ResponseWriter, r *http.Request) {
 	}
 	proxies := make([]any, 0)
 	for _, proxy := range proxiesMap {
-		proxies = append(proxies, proxy)
+		// Strip passwords from the list — use getProxy/:id to retrieve them
+		proxies = append(proxies, configuration.StripProxyPasswords(proxy))
 	}
 	render.JSON(w, r, render.M{
 		"proxies":    proxies,
 		"selectedId": selectedId,
 	})
+}
+
+// getProxy returns a single proxy INCLUDING its password.
+// The Flutter app uses this endpoint after admin elevation to show the password.
+func getProxy(w http.ResponseWriter, r *http.Request) {
+	proxyId := chi.URLParam(r, "proxyId")
+	if proxyId == "" {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, ErrBadRequest)
+		return
+	}
+	proxy, err := configuration.GetProxy(proxyId)
+	if err != nil {
+		render.Status(r, http.StatusNotFound)
+		render.JSON(w, r, NewError(err.Error()))
+		return
+	}
+	render.JSON(w, r, proxy)
 }
 
 func getCurProxy() (string, string) {
@@ -177,7 +199,6 @@ func getCurProxy() (string, string) {
 	}
 
 	return name, addr
-
 }
 
 func handleGetProxy(w http.ResponseWriter, r *http.Request) {

--- a/api/routes/proxy.go
+++ b/api/routes/proxy.go
@@ -30,6 +30,8 @@ func proxyRouter() http.Handler {
 	r.Put("/", addProxy)
 	r.Delete("/all", deleteAllProxies)
 	r.Delete("/", deleteProxies)
+	r.Post("/{proxyId}/lock-password", lockProxyPassword)
+	r.Post("/{proxyId}/reset-password", resetProxyPassword)
 	r.Post("/{proxyId}", updateProxy)
 	r.Get("/delay/{proxyId}", getProxyDelay)
 	r.Get("/udp-test/{proxyId}", testProxyUdp)
@@ -154,7 +156,7 @@ func getProxies(w http.ResponseWriter, r *http.Request) {
 }
 
 // getProxy returns a single proxy INCLUDING its password.
-// The Flutter app uses this endpoint after admin elevation to show the password.
+// If the proxy is locked, passwords are stripped from the response.
 func getProxy(w http.ResponseWriter, r *http.Request) {
 	proxyId := chi.URLParam(r, "proxyId")
 	if proxyId == "" {
@@ -166,6 +168,13 @@ func getProxy(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		render.Status(r, http.StatusNotFound)
 		render.JSON(w, r, NewError(err.Error()))
+		return
+	}
+	// If password is locked, strip it from response
+	if locked, ok := proxy["passwordLocked"].(bool); ok && locked {
+		result := configuration.StripProxyPasswords(proxy)
+		result["passwordLocked"] = true
+		render.JSON(w, r, result)
 		return
 	}
 	render.JSON(w, r, proxy)
@@ -261,6 +270,36 @@ func updateProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := configuration.UpdateProxy(proxyId, req.(map[string]any)); err != nil {
+		render.Status(r, http.StatusInternalServerError)
+		render.JSON(w, r, NewError(err.Error()))
+		return
+	}
+	render.NoContent(w, r)
+}
+
+func lockProxyPassword(w http.ResponseWriter, r *http.Request) {
+	proxyId := chi.URLParam(r, "proxyId")
+	if proxyId == "" {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, ErrBadRequest)
+		return
+	}
+	if err := configuration.LockProxyPassword(proxyId); err != nil {
+		render.Status(r, http.StatusInternalServerError)
+		render.JSON(w, r, NewError(err.Error()))
+		return
+	}
+	render.NoContent(w, r)
+}
+
+func resetProxyPassword(w http.ResponseWriter, r *http.Request) {
+	proxyId := chi.URLParam(r, "proxyId")
+	if proxyId == "" {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, ErrBadRequest)
+		return
+	}
+	if err := configuration.ResetProxyPassword(proxyId); err != nil {
 		render.Status(r, http.StatusInternalServerError)
 		render.JSON(w, r, NewError(err.Error()))
 		return

--- a/api/routes/proxy.go
+++ b/api/routes/proxy.go
@@ -32,6 +32,7 @@ func proxyRouter() http.Handler {
 	r.Delete("/", deleteProxies)
 	r.Post("/{proxyId}/lock-password", lockProxyPassword)
 	r.Post("/{proxyId}/reset-password", resetProxyPassword)
+	r.Get("/{proxyId}/password-status", getPasswordStatus)
 	r.Post("/{proxyId}", updateProxy)
 	r.Get("/delay/{proxyId}", getProxyDelay)
 	r.Get("/udp-test/{proxyId}", testProxyUdp)
@@ -269,11 +270,28 @@ func updateProxy(w http.ResponseWriter, r *http.Request) {
 		render.JSON(w, r, ErrBadRequest)
 		return
 	}
+
+	// Auto stop/start if the manager is running (allows save while active)
+	wasRunning := manager.GetIsStarted()
+	if wasRunning {
+		_ = manager.Close()
+	}
+
 	if err := configuration.UpdateProxy(proxyId, req.(map[string]any)); err != nil {
+		// Restart if we stopped
+		if wasRunning {
+			_ = manager.Start()
+		}
 		render.Status(r, http.StatusInternalServerError)
 		render.JSON(w, r, NewError(err.Error()))
 		return
 	}
+
+	// Restart if it was running
+	if wasRunning {
+		_ = manager.Start()
+	}
+
 	render.NoContent(w, r)
 }
 
@@ -305,4 +323,39 @@ func resetProxyPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	render.NoContent(w, r)
+}
+
+func getPasswordStatus(w http.ResponseWriter, r *http.Request) {
+	proxyId := chi.URLParam(r, "proxyId")
+	if proxyId == "" {
+		render.Status(r, http.StatusBadRequest)
+		render.JSON(w, r, ErrBadRequest)
+		return
+	}
+	proxy, err := configuration.GetProxy(proxyId)
+	if err != nil {
+		render.Status(r, http.StatusNotFound)
+		render.JSON(w, r, NewError(err.Error()))
+		return
+	}
+
+	mode, _ := proxy["passwordMode"].(string)
+	locked, _ := proxy["passwordLocked"].(bool)
+	expired := configuration.CheckPasswordExpiry(proxy)
+	hasPassword := false
+	for _, field := range []string{"password", "passwd", "auth_str"} {
+		if val, ok := proxy[field].(string); ok && val != "" {
+			hasPassword = true
+			break
+		}
+	}
+
+	render.JSON(w, r, render.M{
+		"mode":        mode,
+		"locked":      locked,
+		"expired":     expired,
+		"hasPassword": hasPassword,
+		"setAt":       proxy["passwordSetAt"],
+		"ttlMinutes":  proxy["passwordTTLMinutes"],
+	})
 }

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -94,6 +94,7 @@ func Start(addr string, secret string) error {
 		r.Mount("/dns", dnsRouter())
 		r.Mount("/event", eventRouter())
 		r.Mount("/subscription", subscriptionRouter())
+			r.Mount("/auth", authRouter())
 	})
 	go FileServer(r)
 	err := http.ListenAndServe(addr, r)

--- a/internal/configuration/crypto.go
+++ b/internal/configuration/crypto.go
@@ -1,0 +1,180 @@
+package configuration
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+const encPrefix = "enc:"
+
+// getMachineKey derives a 32-byte AES key from a machine-specific identifier.
+// On Windows it uses the MachineGuid registry value; falls back to hostname.
+func getMachineKey() ([]byte, error) {
+	var machineID string
+
+	if runtime.GOOS == "windows" {
+		out, err := exec.Command("reg", "query",
+			`HKLM\SOFTWARE\Microsoft\Cryptography`, "/v", "MachineGuid").Output()
+		if err == nil {
+			for _, line := range strings.Split(string(out), "\n") {
+				if strings.Contains(line, "MachineGuid") {
+					parts := strings.Fields(line)
+					if len(parts) >= 3 {
+						machineID = strings.TrimSpace(parts[len(parts)-1])
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if machineID == "" {
+		h, err := os.Hostname()
+		if err != nil {
+			machineID = "lux-default-key"
+		} else {
+			machineID = h
+		}
+	}
+
+	salt := "lux_proxy_encryption_v1"
+	hash := sha256.Sum256([]byte(salt + ":" + machineID))
+	return hash[:], nil
+}
+
+// encryptPassword encrypts a plaintext password using AES-GCM.
+// Returns "enc:<base64>" or the original string on error.
+func encryptPassword(plaintext string) string {
+	if plaintext == "" || strings.HasPrefix(plaintext, encPrefix) {
+		return plaintext
+	}
+
+	key, err := getMachineKey()
+	if err != nil {
+		return plaintext
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return plaintext
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return plaintext
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return plaintext
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return encPrefix + base64.StdEncoding.EncodeToString(ciphertext)
+}
+
+// decryptPassword decrypts an "enc:<base64>" password.
+// Returns the original string if it's not encrypted or on error.
+func decryptPassword(encrypted string) string {
+	if !strings.HasPrefix(encrypted, encPrefix) {
+		return encrypted
+	}
+
+	key, err := getMachineKey()
+	if err != nil {
+		return encrypted
+	}
+
+	data, err := base64.StdEncoding.DecodeString(encrypted[len(encPrefix):])
+	if err != nil {
+		return encrypted
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return encrypted
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return encrypted
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return encrypted
+	}
+
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return encrypted
+	}
+
+	return string(plaintext)
+}
+
+// isEncrypted returns true if the value has the enc: prefix.
+func isEncrypted(value string) bool {
+	return strings.HasPrefix(value, encPrefix)
+}
+
+// passwordFields are the proxy map keys that hold sensitive credentials.
+var passwordFields = []string{"password", "passwd", "auth_str"}
+
+// encryptProxyPasswords returns a copy of the proxy map with passwords encrypted.
+func encryptProxyPasswords(proxy map[string]any) map[string]any {
+	result := make(map[string]any, len(proxy))
+	for k, v := range proxy {
+		result[k] = v
+	}
+	for _, field := range passwordFields {
+		if val, ok := result[field]; ok {
+			if str, ok := val.(string); ok && str != "" && !isEncrypted(str) {
+				result[field] = encryptPassword(str)
+			}
+		}
+	}
+	return result
+}
+
+// decryptProxyPasswords returns a copy of the proxy map with passwords decrypted.
+func decryptProxyPasswords(proxy map[string]any) map[string]any {
+	result := make(map[string]any, len(proxy))
+	for k, v := range proxy {
+		result[k] = v
+	}
+	for _, field := range passwordFields {
+		if val, ok := result[field]; ok {
+			if str, ok := val.(string); ok && isEncrypted(str) {
+				result[field] = decryptPassword(str)
+			}
+		}
+	}
+	return result
+}
+
+// stripProxyPasswords returns a copy of the proxy map with password fields removed.
+func stripProxyPasswords(proxy map[string]any) map[string]any {
+	result := make(map[string]any, len(proxy))
+	for k, v := range proxy {
+		result[k] = v
+	}
+	for _, field := range passwordFields {
+		delete(result, field)
+	}
+	return result
+}
+
+// StripProxyPasswords is the exported version for use by other packages.
+func StripProxyPasswords(proxy map[string]any) map[string]any {
+	return stripProxyPasswords(proxy)
+}

--- a/internal/configuration/crypto.go
+++ b/internal/configuration/crypto.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -16,7 +17,9 @@ import (
 const encPrefix = "enc:"
 
 // getMachineKey derives a 32-byte AES key from a machine-specific identifier.
-// On Windows it uses the MachineGuid registry value; falls back to hostname.
+// On Windows it uses the MachineGuid registry value.
+// On macOS it uses the hardware UUID from IOPlatformExpertDevice.
+// Falls back to hostname on other platforms.
 func getMachineKey() ([]byte, error) {
 	var machineID string
 
@@ -29,6 +32,20 @@ func getMachineKey() ([]byte, error) {
 					parts := strings.Fields(line)
 					if len(parts) >= 3 {
 						machineID = strings.TrimSpace(parts[len(parts)-1])
+						break
+					}
+				}
+			}
+		}
+	} else if runtime.GOOS == "darwin" {
+		// Use macOS hardware UUID which is stable across reboots and hostname changes
+		out, err := exec.Command("ioreg", "-rd1", "-c", "IOPlatformExpertDevice").Output()
+		if err == nil {
+			for _, line := range strings.Split(string(out), "\n") {
+				if strings.Contains(line, "IOPlatformUUID") {
+					parts := strings.Split(line, "=")
+					if len(parts) >= 2 {
+						machineID = strings.Trim(strings.TrimSpace(parts[1]), "\"")
 						break
 					}
 				}
@@ -177,4 +194,86 @@ func stripProxyPasswords(proxy map[string]any) map[string]any {
 // StripProxyPasswords is the exported version for use by other packages.
 func StripProxyPasswords(proxy map[string]any) map[string]any {
 	return stripProxyPasswords(proxy)
+}
+
+// LockProxyPassword sets the passwordLocked flag on a proxy.
+// The password is kept intact (encrypted on disk) so the proxy still works,
+// but the API will refuse to reveal it until unlocked.
+func LockProxyPassword(proxyId string) error {
+	config, err := Read()
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for i, proxy := range config.Proxy {
+		if id, ok := proxy["id"].(string); ok && id == proxyId {
+			config.Proxy[i]["passwordLocked"] = true
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("proxy not found: %s", proxyId)
+	}
+
+	return Write(config)
+}
+
+// ResetProxyPassword removes the lock AND wipes the stored password.
+// The user must re-enter the password via the edit form afterward.
+func ResetProxyPassword(proxyId string) error {
+	config, err := Read()
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for i, proxy := range config.Proxy {
+		if id, ok := proxy["id"].(string); ok && id == proxyId {
+			config.Proxy[i]["passwordLocked"] = false
+			for _, field := range passwordFields {
+				config.Proxy[i][field] = ""
+			}
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("proxy not found: %s", proxyId)
+	}
+
+	return Write(config)
+}
+
+// MigrateEncryptPasswords checks if any proxy passwords are stored in plaintext
+// and encrypts them. Called once at startup to transparently upgrade old configs.
+func MigrateEncryptPasswords() error {
+	config, err := Read()
+	if err != nil {
+		return err
+	}
+
+	needsWrite := false
+	for _, proxy := range config.Proxy {
+		for _, field := range passwordFields {
+			if val, ok := proxy[field]; ok {
+				if str, ok := val.(string); ok && str != "" && !isEncrypted(str) {
+					needsWrite = true
+					break
+				}
+			}
+		}
+		if needsWrite {
+			break
+		}
+	}
+
+	if needsWrite {
+		// Write() will encrypt all plaintext passwords
+		return Write(config)
+	}
+	return nil
 }

--- a/internal/configuration/crypto.go
+++ b/internal/configuration/crypto.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 )
 
 const encPrefix = "enc:"
@@ -274,6 +275,80 @@ func MigrateEncryptPasswords() error {
 	if needsWrite {
 		// Write() will encrypt all plaintext passwords
 		return Write(config)
+	}
+	return nil
+}
+
+// CheckPasswordExpiry checks if a proxy's password has expired based on its mode.
+// Returns true if the password should be cleared.
+func CheckPasswordExpiry(proxy map[string]any) bool {
+	mode, _ := proxy["passwordMode"].(string)
+	if mode == "" || mode == "persistent" {
+		return false
+	}
+	if mode == "timed" {
+		ttl, ok := proxy["passwordTTLMinutes"].(float64)
+		if !ok || ttl <= 0 {
+			return false
+		}
+		setAt, ok := proxy["passwordSetAt"].(string)
+		if !ok || setAt == "" {
+			return false
+		}
+		t, err := time.Parse(time.RFC3339, setAt)
+		if err != nil {
+			return false
+		}
+		return time.Since(t).Minutes() > ttl
+	}
+	return false
+}
+
+// ClearExpiredPasswords checks all proxies and clears expired timed passwords.
+func ClearExpiredPasswords() error {
+	config, err := Read()
+	if err != nil {
+		return err
+	}
+
+	changed := false
+	for i, proxy := range config.Proxy {
+		if CheckPasswordExpiry(proxy) {
+			for _, field := range passwordFields {
+				config.Proxy[i][field] = ""
+			}
+			delete(config.Proxy[i], "passwordSetAt")
+			config.Proxy[i]["passwordExpired"] = true
+			changed = true
+		}
+	}
+
+	if changed {
+		return Write(config)
+	}
+	return nil
+}
+
+// ClearOneTimePassword clears the password for a specific proxy if it's in one-time mode.
+func ClearOneTimePassword(proxyId string) error {
+	config, err := Read()
+	if err != nil {
+		return err
+	}
+
+	for i, proxy := range config.Proxy {
+		if id, ok := proxy["id"].(string); ok && id == proxyId {
+			mode, _ := proxy["passwordMode"].(string)
+			if mode == "one-time" {
+				for _, field := range passwordFields {
+					config.Proxy[i][field] = ""
+				}
+				delete(config.Proxy[i], "passwordSetAt")
+				config.Proxy[i]["passwordExpired"] = true
+				return Write(config)
+			}
+			break
+		}
 	}
 	return nil
 }

--- a/internal/configuration/file.go
+++ b/internal/configuration/file.go
@@ -37,13 +37,26 @@ func Read() (Config, error) {
 		config.Subscriptions = []SubscriptionCfg{}
 	}
 
+	// Decrypt passwords so the rest of the app always works with plaintext
+	for i, proxy := range config.Proxy {
+		config.Proxy[i] = decryptProxyPasswords(proxy)
+	}
+
 	return *config, nil
 }
 
 func Write(c Config) error {
 	mux.Lock()
 	defer mux.Unlock()
-	err := writeFile(c)
+
+	// Encrypt passwords before persisting to disk
+	encrypted := c
+	encrypted.Proxy = make([]map[string]any, len(c.Proxy))
+	for i, proxy := range c.Proxy {
+		encrypted.Proxy[i] = encryptProxyPasswords(proxy)
+	}
+
+	err := writeFile(encrypted)
 	if err != nil {
 		return fmt.Errorf("fail to write file: %v", err)
 	}

--- a/internal/configuration/file.go
+++ b/internal/configuration/file.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/igoogolx/itun2socks/pkg/log"
 	"go.uber.org/atomic"
@@ -144,4 +145,14 @@ func Init() {
 	if err := ClearExpiredPasswords(); err != nil {
 		log.Warnln(log.FormatLog(log.ConfigurationPrefix, "failed to clear expired passwords: %v"), err)
 	}
+	// Background goroutine: check and clear expired timed passwords every minute
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			if err := ClearExpiredPasswords(); err != nil {
+				log.Warnln(log.FormatLog(log.ConfigurationPrefix, "periodic expiry check failed: %v"), err)
+			}
+		}
+	}()
 }

--- a/internal/configuration/file.go
+++ b/internal/configuration/file.go
@@ -135,9 +135,13 @@ func fileExists(filename string) bool {
 	return !info.IsDir()
 }
 
-// Init performs one-time initialization including encrypting any plaintext passwords.
+// Init performs one-time initialization including encrypting any plaintext passwords
+// and clearing expired timed passwords.
 func Init() {
 	if err := MigrateEncryptPasswords(); err != nil {
 		log.Warnln(log.FormatLog(log.ConfigurationPrefix, "failed to migrate passwords: %v"), err)
+	}
+	if err := ClearExpiredPasswords(); err != nil {
+		log.Warnln(log.FormatLog(log.ConfigurationPrefix, "failed to clear expired passwords: %v"), err)
 	}
 }

--- a/internal/configuration/file.go
+++ b/internal/configuration/file.go
@@ -134,3 +134,10 @@ func fileExists(filename string) bool {
 	}
 	return !info.IsDir()
 }
+
+// Init performs one-time initialization including encrypting any plaintext passwords.
+func Init() {
+	if err := MigrateEncryptPasswords(); err != nil {
+		log.Warnln(log.FormatLog(log.ConfigurationPrefix, "failed to migrate passwords: %v"), err)
+	}
+}

--- a/internal/configuration/proxy.go
+++ b/internal/configuration/proxy.go
@@ -239,6 +239,12 @@ func AddProxy(proxy map[string]any) (string, error) {
 		return "", err
 	}
 	proxy["id"] = id.String()
+	// Set passwordSetAt for timed/one-time modes
+	if mode, _ := proxy["passwordMode"].(string); mode == "timed" || mode == "one-time" {
+		if pw, _ := proxy["password"].(string); pw != "" {
+			proxy["passwordSetAt"] = time.Now().UTC().Format(time.RFC3339)
+		}
+	}
 	data.Proxy = append(data.Proxy, proxy)
 	err = Write(data)
 	if err != nil {

--- a/internal/configuration/proxy.go
+++ b/internal/configuration/proxy.go
@@ -125,6 +125,13 @@ func UpdateProxy(id string, proxy map[string]any) error {
 	}
 	for i, v := range c.Proxy {
 		if v["id"] == id {
+			// If the update includes a non-empty password, clear the lock
+			for _, field := range passwordFields {
+				if val, ok := proxy[field].(string); ok && val != "" {
+					delete(proxy, "passwordLocked")
+					break
+				}
+			}
 			c.Proxy[i] = proxy
 			break
 		}

--- a/internal/configuration/proxy.go
+++ b/internal/configuration/proxy.go
@@ -1,15 +1,13 @@
 package configuration
-
 import (
 	"fmt"
+	"time"
 	"slices"
 	"strings"
 	"sync"
-
 	"github.com/gofrs/uuid/v5"
 	"github.com/igoogolx/itun2socks/pkg/clash/adapter"
 )
-
 func GetSelectedProxy() (map[string]any, error) {
 	data, err := Read()
 	if err != nil {
@@ -17,7 +15,6 @@ func GetSelectedProxy() (map[string]any, error) {
 	}
 	return GetProxy(data.Selected.Proxy)
 }
-
 func GetProxy(id string) (map[string]any, error) {
 	data, err := Read()
 	if err != nil {
@@ -30,7 +27,6 @@ func GetProxy(id string) (map[string]any, error) {
 	}
 	return nil, fmt.Errorf("error getting selected proxy,id:%v,err:%v", id, err)
 }
-
 func GetProxies() ([]map[string]any, error) {
 	data, err := Read()
 	if err != nil {
@@ -38,7 +34,6 @@ func GetProxies() ([]map[string]any, error) {
 	}
 	return data.Proxy, nil
 }
-
 func GetSubscriptions() ([]SubscriptionCfg, error) {
 	data, err := Read()
 	if err != nil {
@@ -46,7 +41,6 @@ func GetSubscriptions() ([]SubscriptionCfg, error) {
 	}
 	return data.Subscriptions, nil
 }
-
 func DeleteSubscription(id string) error {
 	data, err := Read()
 	if err != nil {
@@ -58,9 +52,7 @@ func DeleteSubscription(id string) error {
 			newSubscriptions = append(newSubscriptions, s)
 		}
 	}
-
 	newProxy := make([]map[string]any, 0)
-
 	for _, v := range data.Proxy {
 		subscriptionId, ok := v["subscription"].(string)
 		if !ok {
@@ -71,18 +63,14 @@ func DeleteSubscription(id string) error {
 			newProxy = append(newProxy, v)
 		}
 	}
-
 	data.Subscriptions = newSubscriptions
 	data.Proxy = newProxy
-
 	err = Write(data)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
-
 func DeleteProxies(ids []string) error {
 	data, err := Read()
 	if err != nil {
@@ -103,7 +91,6 @@ func DeleteProxies(ids []string) error {
 	}
 	return nil
 }
-
 func DeleteAllProxies() error {
 	data, err := Read()
 	if err != nil {
@@ -113,7 +100,6 @@ func DeleteAllProxies() error {
 	err = Write(data)
 	return err
 }
-
 func UpdateProxy(id string, proxy map[string]any) error {
 	_, err := adapter.ParseProxy(proxy)
 	if err != nil {
@@ -129,6 +115,10 @@ func UpdateProxy(id string, proxy map[string]any) error {
 			for _, field := range passwordFields {
 				if val, ok := proxy[field].(string); ok && val != "" {
 					delete(proxy, "passwordLocked")
+					delete(proxy, "passwordExpired")
+					if mode, _ := proxy["passwordMode"].(string); mode == "timed" || mode == "one-time" {
+						proxy["passwordSetAt"] = time.Now().UTC().Format(time.RFC3339)
+					}
 					break
 				}
 			}
@@ -142,7 +132,6 @@ func UpdateProxy(id string, proxy map[string]any) error {
 	}
 	return nil
 }
-
 func checkIsValidStr(value any) (string, bool) {
 	str, ok := value.(string)
 	if !ok {
@@ -153,27 +142,22 @@ func checkIsValidStr(value any) (string, bool) {
 	}
 	return str, true
 }
-
 func AddSubscription(proxies []map[string]any, subscriptionUrl string, subscriptionName string, subscriptionRemark string) ([]map[string]any, []SubscriptionCfg, error) {
 	data, err := Read()
 	if err != nil {
 		return nil, nil, err
 	}
-
 	subscriptionUuid, err := uuid.NewV4()
 	if err != nil {
 		return nil, nil, err
 	}
-
 	subscriptionId := subscriptionUuid.String()
-
 	newProxyWithIds := make([]map[string]any, 0)
 	for _, proxy := range proxies {
 		_, err := adapter.ParseProxy(proxy)
 		if err != nil {
 			return nil, nil, fmt.Errorf("fail to parse proxy,error:%v", err)
 		}
-
 		if _, ok := checkIsValidStr(proxy["id"]); !ok {
 			id, err := uuid.NewV4()
 			if err != nil {
@@ -181,22 +165,18 @@ func AddSubscription(proxies []map[string]any, subscriptionUrl string, subscript
 			}
 			proxy["id"] = id.String()
 		}
-
 		proxy["subscription"] = subscriptionId
 		newProxyWithIds = append(newProxyWithIds, proxy)
 	}
-
 	newSubscription := SubscriptionCfg{Id: subscriptionId, Name: subscriptionName, Remark: subscriptionRemark, Url: subscriptionUrl}
 	data.Proxy = append(data.Proxy, newProxyWithIds...)
 	data.Subscriptions = append(data.Subscriptions, newSubscription)
-
 	err = Write(data)
 	if err != nil {
 		return nil, nil, err
 	}
 	return data.Proxy, data.Subscriptions, nil
 }
-
 func UpdateSubscription(subscription SubscriptionCfg) error {
 	c, err := Read()
 	if err != nil {
@@ -210,50 +190,39 @@ func UpdateSubscription(subscription SubscriptionCfg) error {
 	}
 	return Write(c)
 }
-
 func UpdateSubscriptionProxies(subscriptionId string, proxies []map[string]any) ([]map[string]any, error) {
 	c, err := Read()
 	if err != nil {
 		return nil, err
 	}
-
 	newProxies := make([]map[string]any, 0)
-
 	for _, p := range c.Proxy {
 		if value, ok := p["subscription"].(string); ok && value == subscriptionId {
 			continue
 		}
 		newProxies = append(newProxies, p)
 	}
-
 	for _, proxy := range proxies {
 		_, err := adapter.ParseProxy(proxy)
 		if err != nil {
 			return nil, fmt.Errorf("fail to parse proxy,error:%v", err)
 		}
-
 		id, err := uuid.NewV4()
 		if err != nil {
 			return nil, err
 		}
 		proxy["id"] = id.String()
 		proxy["subscription"] = subscriptionId
-
 		newProxies = append(newProxies, proxy)
 	}
-
 	c.Proxy = newProxies
-
 	err = Write(c)
 	if err != nil {
 		return nil, err
 	}
-
 	return newProxies, nil
 }
-
 var addMux sync.Mutex
-
 func AddProxy(proxy map[string]any) (string, error) {
 	addMux.Lock()
 	defer addMux.Unlock()

--- a/internal/configuration/selected.go
+++ b/internal/configuration/selected.go
@@ -22,9 +22,11 @@ func SetSelectedId(bucket, id string) error {
 	if err != nil {
 		return err
 	}
+	var previousId string
 	if bucket == "rule" {
 		c.Selected.Rule = id
 	} else if bucket == "proxy" {
+		previousId = c.Selected.Proxy
 		c.Selected.Proxy = id
 	} else {
 		return fmt.Errorf("error seting selected id,type:%v err: invalid field", bucket)
@@ -32,6 +34,10 @@ func SetSelectedId(bucket, id string) error {
 	err = Write(c)
 	if err != nil {
 		return err
+	}
+	// Clear one-time password on the previous proxy after saving selection
+	if bucket == "proxy" && previousId != "" && previousId != id {
+		_ = ClearOneTimePassword(previousId)
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	log.InitLog()
 	log.Infoln(log.FormatLog(log.InitPrefix, "using config: %v"), constants.Path.ConfigFilePath())
 	configuration.SetConfigFilePath(constants.Path.ConfigFilePath())
+	configuration.Init()
 	api.Start(port, secret)
 
 	defer func() {

--- a/pkg/network_iface/monitor.go
+++ b/pkg/network_iface/monitor.go
@@ -43,6 +43,36 @@ func StartMonitor() error {
 	}
 	if len(setting.DefaultInterface) != 0 {
 		update(setting.DefaultInterface)
+		// Create a NetworkUpdateMonitor and DefaultInterfaceMonitor even when
+		// DefaultInterface is explicitly configured — sing-tun requires a non-nil
+		// InterfaceMonitor for TUN/mixed mode (NativeTun.Start calls RegisterMyInterface).
+		networkUpdateMonitor, err = tun.NewNetworkUpdateMonitor(logrus.StandardLogger())
+		if err != nil {
+			return E.Cause(err, "create NetworkUpdateMonitor")
+		}
+		err = networkUpdateMonitor.Start()
+		if err != nil {
+			return E.Cause(err, "start NetworkUpdateMonitor")
+		}
+		defaultInterfaceMonitor, err = tun.NewDefaultInterfaceMonitor(
+			networkUpdateMonitor,
+			logrus.StandardLogger(),
+			tun.DefaultInterfaceMonitorOptions{
+				OverrideAndroidVPN: true,
+				InterfaceFinder:    control.NewDefaultInterfaceFinder(),
+			})
+		if err != nil {
+			return E.Cause(err, "create DefaultInterfaceMonitor")
+		}
+		monitorCallback = defaultInterfaceMonitor.RegisterCallback(func(defaultInterface *control.Interface, flags int) {
+			if defaultInterface != nil {
+				update(defaultInterface.Name)
+			}
+		})
+		err = defaultInterfaceMonitor.Start()
+		if err != nil {
+			return E.Cause(err, "start DefaultInterfaceMonitor")
+		}
 		return nil
 	}
 	networkUpdateMonitor, err = tun.NewNetworkUpdateMonitor(logrus.StandardLogger())


### PR DESCRIPTION
## Summary

This PR adds password encryption to the proxy configuration and a new secure endpoint for the Flutter client to retrieve passwords after credential verification.

## Changes

### internal/configuration/crypto.go (new)
AES-GCM encryption/decryption using a machine-derived key:
- Windows: uses MachineGuid from registry + SHA-256 salt
- Other platforms: falls back to hostname
- enc: prefix distinguishes encrypted values from plaintext
- Backward compatible: plaintext values pass through unchanged

### internal/configuration/file.go
- Read() now decrypts all proxy password fields after loading from disk
- Write() now encrypts all proxy password fields before persisting
- Existing plaintext passwords are migrated on the next write

### api/routes/proxy.go
- Add GET /{proxyId} endpoint returning the full proxy config including decrypted password (used by the Flutter app after the user verifies their Windows credentials)
- GET / (list) now strips password fields from the response so the web dashboard can no longer expose plaintext credentials

## Companion PR
Flutter client changes: igoogolx/lux#172

## Notes
- All proxy connections continue to work unchanged (passwords are decrypted before use)
- The web dashboard proxy edit form will show an empty password field (by design)
- config.json will show enc:... values instead of plaintext after first write